### PR TITLE
version 1.0.2

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include setup_mapping.py
 include mapcfunctions.pyx
 include mapping.pxd
 include mapping.pyx
+include mapc.c
 include LICENSE
 include README.md
 include requirements.txt
@@ -9,7 +10,8 @@ graft test
 graft Assets
 include __init__.pxd
 include __init__.py
-pyproject.toml
+include pyproject.toml
+include setup.cfg
 
 
 

--- a/README.md
+++ b/README.md
@@ -332,6 +332,11 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 ```
+## Testing: 
+```python
+>>>from IndexMapping.test.test_mapping import run_test
+>>>run_test()
+```
 
 
 ## Timing :

--- a/__init__.pxd
+++ b/__init__.pxd
@@ -1,1 +1,2 @@
-from IndexMapping.mapping cimport to3d_c, to1d_c, vmap_buffer_c, vfb_rgb_c, vfb_rgba_c, vfb_c
+from mapping cimport xyz, to3d_c, to1d_c, vmap_buffer_c, vfb_rgb_c, vfb_rgba_c, vfb_c
+__all__ = ['xyz', "to3d_c", 'to1d_c', 'vmap_buffer_c', 'vfb_rgb_c', 'vfb_rgba_c', 'vfb_c']

--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,2 @@
 from IndexMapping.mapping import to3d, to1d, vmap_buffer, vfb_rgb, vfb_rgba, vfb
+__all__ = ['to3d', 'to1d', 'vmap_buffer', 'vfb_rgb', 'vfb_rgba', 'vfb']

--- a/build_prj.py
+++ b/build_prj.py
@@ -1,0 +1,39 @@
+
+import subprocess
+import os
+from sys import stdout
+
+build_cython = True
+build_wheel  = True
+test = True
+
+indexmapping_version = "IndexMapping-1.0.2*"
+py_versions = ['%python3_6%', '%python3_7%', '%python3_8%', '%python3_9%', '%python3_10%']
+
+command1 = " setup_mapping.py build_ext --inplace --force"
+command2 = " setup.py sdist bdist_wheel"
+if test:
+    command3 = "C:\\Users\\yoann\\AppData\\Roaming\\Python\\Python36\\Scripts\\twine upload " +\
+        " --verbose --repository testpypi dist/IndexMapping-" + indexmapping_version
+else:
+    command3 = "C:\\Users\\yoann\\AppData\\Roaming\\Python\\Python36\\Scripts\\twine upload " + \
+               " --verbose dist/IndexMapping-" + indexmapping_version
+
+
+def runcmd(cmd):
+    x = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
+    return x.communicate(stdout)
+
+
+if build_cython:
+    # BUILD CYTHON CODE
+    for ver in py_versions:
+        print("\n")
+        os.system('echo %s ' % ver)
+        os.system('%s %s' % (ver, command1))
+
+if build_wheel:
+    for ver in py_versions:
+        print("\n")
+        os.system('echo %s ' % ver)
+        os.system('%s %s' % (ver, command2))

--- a/mapping.pxd
+++ b/mapping.pxd
@@ -1,6 +1,7 @@
 # cython: binding=False, boundscheck=False, wraparound=False, nonecheck=False, cdivision=True, optimize.use_switch=True
 # encoding: utf-8
 
+
 ## License :
 """
 ```
@@ -39,14 +40,15 @@ cdef xyz to3d_c(unsigned int index, unsigned int width, unsigned short int depth
 cdef unsigned int to1d_c(unsigned int x, unsigned int y,
                          unsigned int z, unsigned int width, unsigned short int depth)nogil
 
-cdef int vmap_buffer_c(unsigned int index, unsigned int width, unsigned int height, unsigned short int depth)nogil
+cdef unsigned int vmap_buffer_c(unsigned int index,
+                                unsigned int width, unsigned int height, unsigned short int depth)nogil
 
 cdef unsigned char [:] vfb_rgb_c(
-        unsigned char [:] source, unsigned char [:] target, unsigned int width, unsigned int height)nogil
+        unsigned char [:] source, unsigned char [:] target, int width, int height)nogil
 
 cdef unsigned char [:] vfb_rgba_c(
-        unsigned char [:] source, unsigned char [:] target, unsigned int width, unsigned int height)nogil
+        unsigned char [:] source, unsigned char [:] target, int width, int height)nogil
 
 cdef unsigned char [::1] vfb_c(unsigned char [:] source, unsigned char [::1] target,
-                               unsigned int width, unsigned int height)nogil
+                               int width, int height)nogil
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,58 @@
+[metadata]
+name = IndexMapping
+version = attr: mapping.__version__
+author = Yoann Berenguer
+author_email = yoyoberenguer@hotmail.com
+url = https://github.com/yoyoberenguer/IndexMapping
+description = 1D array transpose/conversion
+long_description = file: README.md
+long_description_content_type = text/markdown
+license = MIT
+license_file = LICENSE
+platform = any
+keywords =
+    Buffer
+    transpose
+    Array indexing
+    1D array to 3D array
+    3D array to 1D array
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    License :: OSI Approved :: MIT License
+    Operating System :: OS Independent
+    Programming Language :: Python
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Topic :: Software Development :: Libraries :: Python Modules
+project_urls =
+    Bug Reports = https://github.com/yoyoberenguer/IndexMapping/issues
+    Source      = https://github.com/yoyoberenguer/IndexMapping
+
+[options]
+zip_safe = false
+include_package_data = true
+python_requires = >= 3.6
+packages = IndexMapping
+
+setup_requires =
+    setuptools >=46.4.0
+    # setuptools >=30.3.0     # minimal version for `setup.cfg`
+    # setuptools >=38.3.0     # version with most `setup.cfg` bugfixes
+    # setuptools >=46.4.0     # let's you use attr: to extract version from a module
+install_requires =
+    requirements.txt
+
+[bdist_wheel]
+universal = true
+
+[sdist]
+formats = zip
+
+
+
+
+

--- a/setup.py
+++ b/setup.py
@@ -42,10 +42,10 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name                         ="IndexMapping",
-    version                      ="1.0.1",
+    version                      ="1.0.2",              # prod 1.0.2  / test 1.0.20 next 1.0.21
     author                       ="Yoann Berenguer",
     author_email                 ="yoyoberenguer@hotmail.com",
-    description                  ="1d array transpose/conversion",
+    description                  ="1D array transpose/conversion",
     long_description             =long_description,
     long_description_content_type="text/markdown",
     url                          ="https://github.com/yoyoberenguer/IndexMapping",
@@ -56,6 +56,7 @@ setuptools.setup(
         Extension("IndexMapping.mapcfunctions", ["mapcfunctions.pyx"],
                   extra_compile_args=["/Qpar", "/fp:fast", "/O2", "/Oy", "/Ot"], language="c")]),
     include_dirs=[numpy.get_include()],
+    define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
     license                      ='MIT',
 
     classifiers=[  # Optional
@@ -85,7 +86,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
-        # 'Programming Language :: Python :: 3 :: Only',
+        'Topic :: Software Development :: Libraries :: Python Modules'
     ],
 
     install_requires=[
@@ -105,11 +106,14 @@ setuptools.setup(
                   'mapping.pyx',
                   'LICENSE',
                   'README.md',
-                  'requirements.txt'
+                  'requirements.txt',
+                  'mapc.c',
+                  'setup.cfg'
 
                   ]),
                 ('./lib/site-packages/IndexMapping/test',
                  [
+                  'test/__init__.py',
                   'test/test_mapping.py',
                   'test/test_split.py',
                   'test/profiling.py'

--- a/setup_mapping.py
+++ b/setup_mapping.py
@@ -1,6 +1,3 @@
-# distutils: extra_compile_args = -fopenmp
-# distutils: extra_link_args = -fopenmp
-
 from distutils.core import setup
 from distutils.extension import Extension
 
@@ -9,9 +6,9 @@ from Cython.Distutils import build_ext
 import numpy
 
 setup(
-    name='mapping',
     ext_modules=cythonize(Extension(
             "*", ['*.pyx'], extra_compile_args=["/Qpar", "/fp:fast", "/O2", "/Oy", "/Ot"], language="c",
+            define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")]
         )
     ),
     include_dirs=[numpy.get_include()],

--- a/test/profiling.py
+++ b/test/profiling.py
@@ -32,41 +32,46 @@ except ImportError:
     raise ImportError("\n<numpy> library is missing on your system."
           "\nTry: \n   C:\\pip install numpy on a window command prompt.")
 
-
+import os
+import IndexMapping
 from IndexMapping.mapping import to1d, to3d, vfb_rgb, vfb_rgba, vfb, vmap_buffer
 
-N = int(1e6)
-t = timeit.timeit("to1d(x=5, y=6, z=3, width=800, depth=3)", "from __main__ import to1d", number = N)
-print("Testing to1d per call %s overall time %s for %s" % (t/N, t, N))
+PROJECT_PATH = IndexMapping.__path__
+os.chdir(PROJECT_PATH[0] + "\\test")
 
-t = timeit.timeit("to3d(2, 800, 3)", "from __main__ import to3d", number = N)
-print("Testing to3d per call %s overall time %s for %s" % (t/N, t, N))
+if __name__ == '__main__':
+    N = int(1e6)
+    t = timeit.timeit("to1d(x=5, y=6, z=3, width=800, depth=3)", "from __main__ import to1d", number=N)
+    print("Testing to1d per call %s overall time %s for %s" % (t / N, t, N))
 
-N = int(1e3)
-size = 800 * 800 * 3
-source_buffer = numpy.empty(size, numpy.uint8)
-target_buffer = numpy.empty(size, numpy.uint8)
-for i in range(size):
-    source_buffer[i] = i
-    target_buffer[i] = i
+    t = timeit.timeit("to3d(2, 800, 3)", "from __main__ import to3d", number=N)
+    print("Testing to3d per call %s overall time %s for %s" % (t / N, t, N))
 
-t = timeit.timeit("vfb_rgb(source_buffer, target_buffer, 800, 800)",
-                  "from __main__ import vfb_rgb, source_buffer, target_buffer", number = N)
-print("Testing vfb_rgb per call %s overall time %s for %s" % (t/N, t, N))
+    N = int(1e3)
+    size = 800 * 800 * 3
+    source_buffer = numpy.empty(size, numpy.uint8)
+    target_buffer = numpy.empty(size, numpy.uint8)
+    for i in range(size):
+        source_buffer[i] = i
+        target_buffer[i] = i
 
-N = int(1e6)
-t = timeit.timeit("vmap_buffer(10, 64, 64, 3)",
-                  "from __main__ import vmap_buffer", number = N)
-print("Testing vmap_buffer per call %s overall time %s for %s" % (t/N, t, N))
+    t = timeit.timeit("vfb_rgb(source_buffer, target_buffer, 800, 800)",
+                      "from __main__ import vfb_rgb, source_buffer, target_buffer", number=N)
+    print("Testing vfb_rgb per call %s overall time %s for %s" % (t / N, t, N))
 
-N = int(1e3)
-size = 800 * 800 * 4
-source_buffer = numpy.empty(size, numpy.uint8)
-target_buffer = numpy.empty(size, numpy.uint8)
-for i in range(size):
-    source_buffer[i] = i
-    target_buffer[i] = i
+    N = int(1e6)
+    t = timeit.timeit("vmap_buffer(10, 64, 64, 3)",
+                      "from __main__ import vmap_buffer", number=N)
+    print("Testing vmap_buffer per call %s overall time %s for %s" % (t / N, t, N))
 
-t = timeit.timeit("vfb_rgba(source_buffer, target_buffer, 800, 800)",
-                  "from __main__ import vfb_rgba, source_buffer, target_buffer", number = N)
-print("Testing vfb_rgba per call %s overall time %s for %s" % (t/N, t, N))
+    N = int(1e3)
+    size = 800 * 800 * 4
+    source_buffer = numpy.empty(size, numpy.uint8)
+    target_buffer = numpy.empty(size, numpy.uint8)
+    for i in range(size):
+        source_buffer[i] = i
+        target_buffer[i] = i
+
+    t = timeit.timeit("vfb_rgba(source_buffer, target_buffer, 800, 800)",
+                      "from __main__ import vfb_rgba, source_buffer, target_buffer", number=N)
+    print("Testing vfb_rgba per call %s overall time %s for %s" % (t / N, t, N))

--- a/test/test_mapping.py
+++ b/test/test_mapping.py
@@ -45,9 +45,12 @@ except ImportError:
     raise ImportError("\n<Pygame> library is missing on your system."
           "\nTry: \n   C:\\pip install pygame on a window command prompt.")
 
+import os
+import IndexMapping
+from IndexMapping.mapping import to1d, to3d, vfb_rgb, vfb_rgba, vfb, vmap_buffer
 
-from mapping import to1d, to3d, vfb_rgb, vfb_rgba, vfb, vmap_buffer
-
+PROJECT_PATH = IndexMapping.__path__
+os.chdir(PROJECT_PATH[0] + "\\test")
 
 class Test_to1d(unittest.TestCase):
 
@@ -263,10 +266,8 @@ class Test_vfb_rgb(unittest.TestCase):
         self.assertIsInstance(flipped_buffer, numpy.ndarray)
         self.assertTrue(flipped_buffer.dtype, numpy.uint8)
 
-        self.assertRaises(OverflowError, vfb_rgb, source_buffer, target_buffer, -32, 32)
-        self.assertRaises(OverflowError, vfb_rgb, source_buffer, target_buffer, 32, -32)
-        self.assertRaises(OverflowError, vfb_rgb, source_buffer, target_buffer, 4294967295 + 1, 4294967295)
-        self.assertRaises(OverflowError, vfb_rgb, source_buffer, target_buffer, 4294967295, 4294967295 + 1)
+        self.assertRaises(AssertionError, vfb_rgb, source_buffer, target_buffer, -32, 32)
+        self.assertRaises(AssertionError, vfb_rgb, source_buffer, target_buffer, 32, -32)
         self.assertRaises(TypeError, vfb_rgb, [r for r in range(100)], target_buffer, 4294967295, 4294967295)
         self.assertRaises(TypeError, vfb_rgb, source_buffer, [r for r in range(100)], 4294967295, 4294967295)
         self.assertRaises(ValueError, vfb_rgb, numpy.empty((10, 10), numpy.uint8), target_buffer, 4294967295, 4294967295)
@@ -409,10 +410,8 @@ class Test_vfb_rgba(unittest.TestCase):
         value = vfb_rgba(source_buffer, target_buffer, 3, 3)
         self.assertIsInstance(value, numpy.ndarray)
 
-        self.assertRaises(OverflowError, vfb_rgba, source_buffer, target_buffer, -32, 32)
-        self.assertRaises(OverflowError, vfb_rgba, source_buffer, target_buffer, 32, -32)
-        self.assertRaises(OverflowError, vfb_rgba, source_buffer, target_buffer, 4294967295 + 1, 4294967295)
-        self.assertRaises(OverflowError, vfb_rgba, source_buffer, target_buffer, 4294967295, 4294967295 + 1)
+        self.assertRaises(AssertionError, vfb_rgba, source_buffer, target_buffer, -32, 32)
+        self.assertRaises(AssertionError, vfb_rgba, source_buffer, target_buffer, 32, -32)
         self.assertRaises(TypeError, vfb_rgba, [r for r in range(100)], target_buffer, 4294967295, 4294967295)
         self.assertRaises(TypeError, vfb_rgba, source_buffer, [r for r in range(100)], 4294967295, 4294967295)
         self.assertRaises(ValueError, vfb_rgba, numpy.empty((10, 10), numpy.uint8), target_buffer, 4294967295,
@@ -488,9 +487,7 @@ class Test_display_vfb_rgba(unittest.TestCase):
                 break
 
 
-
-if __name__ == '__main__':
-
+def run_test():
     suite = unittest.TestSuite()
 
     suite.addTests([Test_to1d(),
@@ -504,152 +501,15 @@ if __name__ == '__main__':
                     Test_vfb_rgba(),
                     Test_display_vfb_rgba()
 
-    ])
+                    ])
 
     unittest.TextTestRunner().run(suite)
+    pygame.quit()
+
+
+if __name__ == '__main__':
+   pass
 
 
 
 
-    # # background_b = background_rgb # .transpose(1, 0, 2)
-    # # background_b = background_b.flatten()
-    # # im = testing_pure_c(background_b.astype(dtype=numpy.uint8), 400, 400)
-
-    # im = pygame.image.frombuffer(background_b, (w, h), 'RGB')
-    # screen.fill((0, 0, 0))
-    # screen.blit(im, (0, 0))
-    #
-    # new_buffer = numpy.asarray(background_b).reshape(h, w, 3).transpose(1, 0, 2)
-    # im = pygame.surfarray.make_surface(new_buffer)
-    # screen.blit(im, (w, 0))
-    # pygame.display.flip()
-    # print('\nTESTING TO1D')
-    # pygame.time.wait(1000)
-    #
-    # for r in range(w * h * 3):
-    #     v = to3d(r, w, 3)
-    #     x, y, z = v['x'], v['y'], v['z']
-    #     background_rgb[x][y][z] = background_b[r]
-    #
-    # im = pygame.surfarray.make_surface(background_rgb)
-    # screen.fill((0, 0, 0))
-    # screen.blit(im, (0, 0))
-    # pygame.display.flip()
-    # print('\nTESTING TO3D')
-    # pygame.time.wait(1000)
-    #
-    # # TESTING VFB_RGB (RGB ARRAY FLIP)
-    # # RELOADING RGB ARRAY
-    # background_rgb = pygame.surfarray.pixels3d(background)
-    # # FLAT THE ARRAY IN A BUFFER
-    # background_flat = background_rgb.flatten()
-    #
-    # background_c = numpy.empty(w * h * 3, dtype=numpy.uint8)
-    # # TRANSPOSE THE ARRAY
-    # flipped = vfb_rgb(background_flat, background_c, w, h)
-    # back = pygame.image.frombuffer(flipped, (w, h), 'RGB')
-    # back1 = pygame.surfarray.make_surface(numpy.asarray(flipped).reshape(h, w, 3))
-    # screen.fill((0, 0, 0))
-    # screen.blit(back, (0, 0))
-    # screen.blit(back1, (w, 0))
-    # pygame.display.flip()
-    # print('\nTESTING VFB_RGB')
-    # pygame.time.wait(2000)
-    #
-    # # TESTING vfb_rgba
-    # background = pygame.image.load('A1.png').convert_alpha()
-    # background = pygame.transform.smoothscale(background, (w, h))
-    # rgb_array = pygame.surfarray.pixels3d(background)
-    # alpha = pygame.surfarray.pixels_alpha(background)
-    # print(rgb_array.shape)
-    # print(alpha.shape)
-    # rgba_array = numpy.dstack((rgb_array, alpha)).astype(dtype=numpy.uint8)
-    # print(rgba_array.shape)
-    # print(rgba_array.flags)
-    # surface = pygame.image.frombuffer(
-    #     numpy.ascontiguousarray(rgba_array.transpose(1, 0, 2)), (w, h), 'RGBA')
-    # target = numpy.empty((w * h * 4), dtype=numpy.uint8)
-    # source = rgba_array.flatten()
-    # surface = pygame.image.frombuffer(vfb_rgba(source, target, w, h), (w, h), 'RGBA')
-    # i = 0
-    #
-    # # RETURN RGBA VALUES AND ARRAY SHAPE (WIDTH, HEIGHT)
-    # buffer_ = background.get_view('2')
-    # print(numpy.asarray(buffer_).shape, buffer_.length)
-    #
-    # # RETURN RGB VALUES AND ARRAY SHAPE (WIDTH, HEIGHT, 3)
-    # buffer_ = background.get_view('3')
-    # print(numpy.asarray(buffer_).shape, buffer_.length)
-    #
-    # buffer_ = background.get_view('2')
-    # new_buffer = numpy.frombuffer(buffer_, dtype=numpy.uint8)
-    # print(new_buffer.shape)
-    # flipped_image = pygame.image.frombuffer(new_buffer, (w, h), 'RGBA')
-    # # CREATE AND FLIP THE BUFFER
-    # flipped_buffer = flipped_image.get_view('2')
-    # flipped_buffer = numpy.frombuffer(flipped_buffer, numpy.uint8).reshape(w, h, 4)
-    # flipped_buffer = flipped_buffer.transpose(1, 0, 2).flatten()
-    # # LOAD THE ORIGINAL BUFFER AND FLIP IT TOO WITH vfb_rgba TO COMPARE BOTH BUFFER
-    # target = numpy.empty((w * h * 4), numpy.uint8)
-    # other_flipped_buffer = vfb_rgba(numpy.frombuffer(background.get_view('2'), numpy.uint8), target, w, h)
-    # print(len(flipped_buffer), other_flipped_buffer.shape)
-    # # COMPARE BOTH FLIPPED BUFFERS
-    # for r in range(len(flipped_buffer)):
-    #     if flipped_buffer[r] != other_flipped_buffer[r]:
-    #         print(flipped_buffer[r], other_flipped_buffer[r])
-    #         raise ValueError('\nArray are not identical')
-    #
-    # # TEST vfb_c
-    # alpha_image = pygame.image.load('Radial4.png').convert_alpha()
-    # alpha_image = pygame.transform.smoothscale(alpha_image, (w, h))
-    # alpha_buffer = alpha_image.get_view('a')
-    # print(alpha_buffer.length)
-    # target = numpy.empty((w * h), numpy.uint8)
-    # alpha_buffer = numpy.asarray(alpha_buffer)  # .transpose(1, 0)
-    # alpha_buffer = alpha_buffer.flatten()
-    # alpha_buffer_transposed = vfb(alpha_buffer, target, w, h)
-    # alpha_buffer_original_transposed = numpy.asarray(
-    #     alpha_image.get_view('a')).transpose(1, 0)
-    # alpha_buffer_original_transposed = alpha_buffer_original_transposed.flatten()
-    #
-    # for r in range(len(alpha_buffer_transposed)):
-    #     if alpha_buffer_transposed[r] != alpha_buffer_original_transposed[r]:
-    #         print(alpha_buffer_transposed[r], alpha_buffer_original_transposed[r])
-    #         raise ValueError('\nALPHA Array are not identical')
-    #
-    # N = w * h
-    # print("TO1D ", timeit.timeit("to1d(1, 1, 0, 400, 3)", "from __main__ import to1d", number=N))
-    # print("TO3D ", timeit.timeit("to3d(1, 400, 3)", "from __main__ import to3d", number=N))
-    # N = 1000
-    # print("VFB_RGB ", timeit.timeit("vfb_rgb(background_flat, background_c, 400, 400)",
-    #                                 "from __main__ import vfb_rgb, background_flat, background_c", number=N) / N)
-    # print("PURE C ", timeit.timeit("testing_pure_c(background_flat, 400, 400)",
-    #                                "from __main__ import testing_pure_c, background_flat", number=N) / N)
-    # target = numpy.empty((w * h * 4), numpy.uint8)
-    # print("VFB_RGBA C ", timeit.timeit("vfb_rgba(source, target, w, h)",
-    #                                    "from __main__ import vfb_rgba, source, target, w, h", number=N) / N)
-    # target = numpy.empty((w * h), numpy.uint8)
-    # print("VFB C ", timeit.timeit("vfb(alpha_buffer, target, w, h)",
-    #                               "from __main__ import vfb, alpha_buffer, target, w, h", number=N) / N)
-    #
-    # while 1:
-    #     pygame.event.pump()
-    #     keys = pygame.key.get_pressed()
-    #     for event in pygame.event.get():
-    #         if event.type == pygame.MOUSEMOTION:
-    #             MOUSE_POS = event.pos
-    #
-    #     if keys[pygame.K_F8]:
-    #         pygame.image.save(screen, 'Screendump' + str(i) + '.png')
-    #
-    #     if keys[pygame.K_ESCAPE]:
-    #         break
-    #
-    #     screen.fill((0, 0, 0))
-    #
-    #     screen.blit(flipped_image, (0, 0))
-    #
-    #     pygame.display.flip()
-    #
-    #     i += 1
-    # pygame.quit()

--- a/test/test_split.py
+++ b/test/test_split.py
@@ -42,9 +42,14 @@ except ImportError:
     raise ImportError("\n<Pygame> library is missing on your system."
           "\nTry: \n   C:\\pip install pygame on a window command prompt.")
 
+import os
+import IndexMapping
 from IndexMapping.mapcfunctions import testing_pure_c, test_c_inplace, rgb_inplace
 
-if __name__ == '__main__':
+PROJECT_PATH = IndexMapping.__path__
+os.chdir(PROJECT_PATH[0] + "\\test")
+
+def run_test_split():
 
     w, h = 800, 1024
     screen = pygame.display.set_mode((w * 2, h))
@@ -72,4 +77,7 @@ if __name__ == '__main__':
         timer += 1
         pygame.display.flip()
         CLOCK.tick()
-        # print(CLOCK.get_fps())
+
+
+if __name__ == '__main__':
+    pass


### PR DESCRIPTION
+   Removed warning during compilation signed/unsigned mismatch warning (C4018 in Visual Studio).
    Replacing int with some unsigned type is a problem because we frequently use OpenMP pragmas, 
    and it requires the counter to be int.
+   Added define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")] to setup.py file and setup_mapping.py to 
    get rid of this warning
+   corrected the variables x, y, z (now unsigned int) in mapping.pxd  
    cdef struct xyz:
        unsigned int x;
        unsigned int y;
        unsigned int z;
+   Changed vfb_c function call to inline, e.g
    cdef inline unsigned char [::1] vfb_c(unsigned char [:] source,
                unsigned char [::1] target, int width, int height)nogil:
+  Added 
   assert width > 0, 'Argument width cannot be <=0'
   assert height > 0, 'Argument height cannot be <=0'
   in functions vfb_rgb & vfb_rgba
   
+  Corrected the __init__.py and __init__.pxd 
+  Changed variable range for methods vfb_rgb, vfb_rgba, vfb (width and height) are now int instead 
   of unsigned int. Changed the test_mapping.py to reflect those changes  
+  corrected profiling to be run from command line